### PR TITLE
refactor find sample to external files

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,106 +4,13 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
     <title>Find | Sample | ArcGIS Maps SDK for JavaScript 4.32</title>
-    <style>
-      html,
-      body {
-        height: 100%;
-        width: 100%;
-        margin: 0;
-        padding: 0;
-      }
-
-      td {
-        padding: 4px;
-      }
-    </style>
+    <link rel="stylesheet" href="public/css/styles.css">
 
     <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
     <script src="https://js.arcgis.com/4.32/"></script>
     <script type="module" src="https://js.arcgis.com/calcite-components/3.0.3/calcite.esm.js"></script>
 
-    <script>
-      require(["esri/rest/find", "esri/rest/support/FindParameters"], function (find, FindParameters) {
-        const calciteLoader = document.getElementById("calciteLoader");
-
-        // Create a URL pointing to a map service
-        const findUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer";
-
-        // Set parameters to only query the Counties layer by name
-        const params = new FindParameters({
-          layerIds: [0],
-          searchFields: ["areaname"]
-        });
-
-        // Executes on each button click
-        function doFind() {
-          // Display loading gif to provide the user feedback on search progress
-          calciteLoader.hidden = false;
-          // Set the search text to the value of the input box
-          params.searchText = document.getElementById("inputTxt").value;
-          // The find() performs a LIKE SQL query based on the provided text value
-          // showResults() is called once the promise returned here resolves
-          find.find(findUrl, params).then(showResults).catch(rejectedPromise);
-        }
-
-        const resultsTable = document.getElementById("tbl");
-
-        // Executes when the promise from find.execute() resolves
-        function showResults(response) {
-          const results = response.results;
-
-          // Clear the cells and rows of the table to make room for new results
-          resultsTable.innerHTML = "";
-
-          // If no results are returned from the find, notify the user
-          if (results.length === 0) {
-            resultsTable.innerHTML = "<i>No results found</i>";
-            calciteLoader.hidden = true;
-            return;
-          }
-
-          // Set up row for descriptive headers to display results
-          let topRow = resultsTable.insertRow(0);
-          let cell1 = topRow.insertCell(0);
-          let cell2 = topRow.insertCell(1);
-          let cell3 = topRow.insertCell(2);
-          let cell4 = topRow.insertCell(3);
-          cell1.innerHTML = "<b>City Name</b>";
-          cell2.innerHTML = "<b>State Abbreviation</b>";
-          cell3.innerHTML = "<b>Population (2000)</b>";
-          cell4.innerHTML = "<b>Is state capital?</b>";
-
-          // Loop through each result in the response and add as a row in the table
-          results.forEach(function (findResult, i) {
-            // Get each value of the desired attributes
-            const city = findResult.feature.attributes["AREANAME"];
-            const state = findResult.feature.attributes["ST"];
-            const pop2000 = findResult.feature.attributes["POP2000"];
-            const capital = findResult.feature.attributes["CAPITAL"];
-
-            // Add each resulting value to the table as a row
-            const row = resultsTable.insertRow(i + 1);
-            let cell1 = row.insertCell(0);
-            let cell2 = row.insertCell(1);
-            let cell3 = row.insertCell(2);
-            let cell4 = row.insertCell(3);
-            cell1.innerHTML = city;
-            cell2.innerHTML = state;
-            cell3.innerHTML = pop2000;
-            cell4.innerHTML = capital;
-          });
-          calciteLoader.hidden = true;
-        }
-
-        // Executes each time the promise from find.execute() is rejected.
-        function rejectedPromise(error) {
-          console.error("Promise didn't resolve: ", error.message);
-        }
-
-        // Run doFind() when button is clicked
-        document.getElementById("findBtn").addEventListener("click", doFind);
-      });
-    </script>
+    <script type="module" src="public/js/find.js"></script>
   </head>
   <body>
     <div class="esri-widget">

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,0 +1,11 @@
+html,
+body {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+td {
+  padding: 4px;
+}

--- a/public/js/find.js
+++ b/public/js/find.js
@@ -1,0 +1,84 @@
+export let doFind;
+export let showResults;
+export let rejectedPromise;
+
+require(["esri/rest/find", "esri/rest/support/FindParameters"], function (find, FindParameters) {
+  const calciteLoader = document.getElementById("calciteLoader");
+
+  // Create a URL pointing to a map service
+  const findUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer";
+
+  // Set parameters to only query the Counties layer by name
+  const params = new FindParameters({
+    layerIds: [0],
+    searchFields: ["areaname"]
+  });
+
+  // Executes on each button click
+  doFind = function () {
+    // Display loading gif to provide the user feedback on search progress
+    calciteLoader.hidden = false;
+    // Set the search text to the value of the input box
+    params.searchText = document.getElementById("inputTxt").value;
+    // The find() performs a LIKE SQL query based on the provided text value
+    // showResults() is called once the promise returned here resolves
+    find.find(findUrl, params).then(showResults).catch(rejectedPromise);
+  };
+
+  const resultsTable = document.getElementById("tbl");
+
+  // Executes when the promise from find.execute() resolves
+  showResults = function (response) {
+    const results = response.results;
+
+    // Clear the cells and rows of the table to make room for new results
+    resultsTable.innerHTML = "";
+
+    // If no results are returned from the find, notify the user
+    if (results.length === 0) {
+      resultsTable.innerHTML = "<i>No results found</i>";
+      calciteLoader.hidden = true;
+      return;
+    }
+
+    // Set up row for descriptive headers to display results
+    let topRow = resultsTable.insertRow(0);
+    let cell1 = topRow.insertCell(0);
+    let cell2 = topRow.insertCell(1);
+    let cell3 = topRow.insertCell(2);
+    let cell4 = topRow.insertCell(3);
+    cell1.innerHTML = "<b>City Name</b>";
+    cell2.innerHTML = "<b>State Abbreviation</b>";
+    cell3.innerHTML = "<b>Population (2000)</b>";
+    cell4.innerHTML = "<b>Is state capital?</b>";
+
+    // Loop through each result in the response and add as a row in the table
+    results.forEach(function (findResult, i) {
+      // Get each value of the desired attributes
+      const city = findResult.feature.attributes["AREANAME"];
+      const state = findResult.feature.attributes["ST"];
+      const pop2000 = findResult.feature.attributes["POP2000"];
+      const capital = findResult.feature.attributes["CAPITAL"];
+
+      // Add each resulting value to the table as a row
+      const row = resultsTable.insertRow(i + 1);
+      let cell1 = row.insertCell(0);
+      let cell2 = row.insertCell(1);
+      let cell3 = row.insertCell(2);
+      let cell4 = row.insertCell(3);
+      cell1.innerHTML = city;
+      cell2.innerHTML = state;
+      cell3.innerHTML = pop2000;
+      cell4.innerHTML = capital;
+    });
+    calciteLoader.hidden = true;
+  };
+
+  // Executes each time the promise from find.execute() is rejected.
+  rejectedPromise = function (error) {
+    console.error("Promise didn't resolve: ", error.message);
+  };
+
+  // Run doFind() when button is clicked
+  document.getElementById("findBtn").addEventListener("click", doFind);
+});


### PR DESCRIPTION
## Summary
- move find logic into `public/js/find.js` and export key functions
- relocate inline styles to `public/css/styles.css`
- update `index.html` to link external CSS and module script

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a1635b0e48326b43a3d3525fa9bb1