### PR TITLE
Guard DOM references and load find script after DOM

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
     <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
     <script type="module" src="https://js.arcgis.com/4.32/"></script>
     <script type="module" src="https://js.arcgis.com/calcite-components/3.0.3/calcite.esm.js"></script>
-    <script type="module" src="./public/js/find.js"></script>
   </head>
   <body>
     <div class="esri-widget">
@@ -20,6 +19,8 @@
       <input type="button" value="Find" id="findBtn" />
       <calcite-loader id="calciteLoader" label="loading" type="indeterminate" hidden=true></calcite-loader>
       <table id="tbl"></table>
+      <div id="errorMsg"></div>
     </div>
+    <script type="module" src="./public/js/find.js"></script>
   </body>
 </html>

--- a/public/js/find.js
+++ b/public/js/find.js
@@ -2,6 +2,10 @@ import find from "esri/rest/find";
 import FindParameters from "esri/rest/support/FindParameters";
 
 const calciteLoader = document.getElementById("calciteLoader");
+const resultsTable = document.getElementById("tbl");
+const findButton = document.getElementById("findBtn");
+const inputTxt = document.getElementById("inputTxt");
+const errorMsg = document.getElementById("errorMsg");
 
 // Create a URL pointing to a map service
 const findUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer";
@@ -14,10 +18,18 @@ const params = new FindParameters({
 
 // Executes on each button click
 async function doFind() {
-  // Display loading gif to provide the user feedback on search progress
-  calciteLoader.hidden = false;
+  if (calciteLoader) {
+    calciteLoader.hidden = false;
+  }
+  if (errorMsg) {
+    errorMsg.textContent = "";
+  }
+  if (!inputTxt) {
+    console.error("inputTxt element not found");
+    return;
+  }
   // Set the search text to the value of the input box
-  params.searchText = document.getElementById("inputTxt").value;
+  params.searchText = inputTxt.value;
   // The find() performs a LIKE SQL query based on the provided text value
   // showResults() is called once the promise returned here resolves
   try {
@@ -28,11 +40,16 @@ async function doFind() {
   }
 }
 
-const resultsTable = document.getElementById("tbl");
-
 // Executes when the promise from find.execute() resolves
 function showResults(response) {
   const results = response.results;
+
+  if (!resultsTable) {
+    if (calciteLoader) {
+      calciteLoader.hidden = true;
+    }
+    return;
+  }
 
   // Clear the cells and rows of the table to make room for new results
   resultsTable.innerHTML = "";
@@ -40,7 +57,9 @@ function showResults(response) {
   // If no results are returned from the find, notify the user
   if (results.length === 0) {
     resultsTable.innerHTML = "<i>No results found</i>";
-    calciteLoader.hidden = true;
+    if (calciteLoader) {
+      calciteLoader.hidden = true;
+    }
     return;
   }
 
@@ -74,13 +93,24 @@ function showResults(response) {
     cell3.innerHTML = pop2000;
     cell4.innerHTML = capital;
   });
-  calciteLoader.hidden = true;
+
+  if (calciteLoader) {
+    calciteLoader.hidden = true;
+  }
 }
 
 // Executes each time the promise from find.execute() is rejected.
 function rejectedPromise(error) {
   console.error("Promise didn't resolve: ", error.message);
+  if (calciteLoader) {
+    calciteLoader.hidden = true;
+  }
+  if (errorMsg) {
+    errorMsg.textContent = `Error: ${error.message}`;
+  }
 }
 
 // Run doFind() when button is clicked
-document.getElementById("findBtn").addEventListener("click", doFind);
+if (findButton) {
+  findButton.addEventListener("click", doFind);
+}


### PR DESCRIPTION
## Summary
- Move `find.js` from the head to the end of `body` so it runs after the DOM loads
- Add placeholder for error messages and ensure UI elements exist before use

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a1bab09c483269d1af2745640e7be