### PR TITLE
fix arcgis module import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Web Find Sample
+
+This sample demonstrates using the ArcGIS Maps SDK for JavaScript to perform a find operation on a map service.
+
+## Development
+
+Serve the project over HTTP to avoid CORS issues when loading ES modules:
+
+```bash
+python -m http.server 8000
+```
+
+Then open [http://localhost:8000/](http://localhost:8000/) in your browser.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
     <link rel="stylesheet" href="public/css/styles.css">
 
     <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
-    <script type="module" src="https://js.arcgis.com/4.32/"></script>
     <script type="module" src="https://js.arcgis.com/calcite-components/3.0.3/calcite.esm.js"></script>
   </head>
   <body>

--- a/public/js/find.js
+++ b/public/js/find.js
@@ -1,4 +1,4 @@
-import find from "https://js.arcgis.com/4.32/@arcgis/core/rest/find.js";
+import * as find from "https://js.arcgis.com/4.32/@arcgis/core/rest/find.js";
 import FindParameters from "https://js.arcgis.com/4.32/@arcgis/core/rest/support/FindParameters.js";
 
 const calciteLoader = document.getElementById("calciteLoader");


### PR DESCRIPTION
## Summary
- remove ArcGIS loader script from index and rely on direct ESM imports
- import ArcGIS find module as namespace to avoid missing default export
- add README with instructions to serve files to prevent CORS issues

## Testing
- `python -m http.server 8000` then `curl -s http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689a41b062f88326a578ddb48f772dcf